### PR TITLE
Enable category navigation from app modal

### DIFF
--- a/script.js
+++ b/script.js
@@ -2437,8 +2437,8 @@
                 }
                 
                 // Create category tags
-                const categoryTags = app.categories.map(cat => 
-                    `<span class="category-tag">${cat}</span>`
+                const categoryTags = app.categories.map(cat =>
+                    `<button class="category-tag category-select-btn" data-category="${cat}">${cat}</button>`
                 ).join('');
                 
                 const modal = document.createElement('div');
@@ -2497,6 +2497,22 @@
                     document.body.style.overflow = 'auto';
                     setUrlParam('app', '');
                 }
+            });
+
+            // Enable category tag navigation from within the modal
+            modal.querySelectorAll('.modal-categories .category-tag').forEach(tag => {
+                tag.addEventListener('click', () => {
+                    const category = tag.textContent;
+                    modal.classList.remove('active');
+                    document.body.style.overflow = 'auto';
+                    setUrlParam('app', '');
+                    const categoryTab = document.querySelector('.tab[data-tab="categories"]');
+                    if (categoryTab) {
+                        categoryTab.click();
+                    }
+                    setUrlParam('category', category);
+                    renderAppsForCategory(category);
+                });
             });
 
             return modal;

--- a/styles.css
+++ b/styles.css
@@ -740,6 +740,7 @@
             color: #ddd;
             border: 1px solid rgba(255, 255, 255, 0.1);
             box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+            cursor: pointer;
         }
 
         .modal-section {


### PR DESCRIPTION
## Summary
- Make category tags in app modal interactive buttons
- Navigate to the selected category tab when clicking modal tags
- Show pointer cursor for category tags

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68934b8e9a748329940e81b70ca9cbc7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Category tags in the app detail modal are now interactive buttons. Clicking a category tag will close the modal and take you directly to the category view filtered by the selected category.

* **Style**
  * Category tags now display a pointer cursor on hover to indicate they are clickable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->