### PR TITLE
Add torrent download buttons to app version modals

### DIFF
--- a/script.js
+++ b/script.js
@@ -2667,9 +2667,29 @@
         }
 
         // Create a modal for a single app when needed
+        function getArchiveIdentifier(app) {
+            if (!app || !app.versions || !Array.isArray(app.versions.archived)) {
+                return null;
+            }
+
+            for (const version of app.versions.archived) {
+                if (!version || typeof version.url !== 'string') {
+                    continue;
+                }
+
+                const match = version.url.match(/https?:\/\/archive\.org\/download\/([^/]+)\//i);
+                if (match && match[1]) {
+                    return match[1];
+                }
+            }
+
+            return null;
+        }
+
         function createModal(app) {
             // Create version list items
             let versionItems = '';
+            let torrentButtonHtml = '';
                 
                 // Add archived versions if they exist
                 if (app.versions.archived.length > 0) {
@@ -2707,10 +2727,22 @@
                     `<button class="category-tag category-select-btn" data-category="${cat}">${cat}</button>`
                 ).join('');
                 
+                const archiveIdentifier = getArchiveIdentifier(app);
+                if (archiveIdentifier) {
+                    const torrentUrl = `https://archive.org/download/${archiveIdentifier}/${archiveIdentifier}_archive.torrent`;
+                    torrentButtonHtml = `
+                        <div class="torrent-button-container">
+                            <a href="${torrentUrl}" download class="download-button torrent-button">
+                                <i class="fas fa-magnet"></i> Download Torrent
+                            </a>
+                        </div>
+                    `;
+                }
+
                 const modal = document.createElement('div');
                 modal.className = 'modal-overlay';
                 modal.id = `${app.id}Modal`;
-                
+
                 modal.innerHTML = `
                     <div class="modal-content">
                         <button class="close-modal">&times;</button>
@@ -2745,10 +2777,11 @@
                                     ${versionItems}
                                 </div>
                             </div>
+                            ${torrentButtonHtml}
                         </div>
                     </div>
                 `;
-                
+
             modalContainer.appendChild(modal);
 
             modal.querySelector('.close-modal').addEventListener('click', function() {

--- a/styles.css
+++ b/styles.css
@@ -870,9 +870,23 @@
 
         .download-button:active {
             transform: translateY(1px);
-            box-shadow: 
+            box-shadow:
                 0 1px 2px rgba(0, 0, 0, 0.2),
                 inset 0 1px 0 rgba(255, 255, 255, 0.1);
+        }
+
+        .torrent-button-container {
+            display: flex;
+            justify-content: flex-end;
+            margin-top: 16px;
+        }
+
+        .torrent-button {
+            gap: 8px;
+        }
+
+        .torrent-button i {
+            color: #ffd166;
         }
 
         /* Scrollbar styling */


### PR DESCRIPTION
## Summary
- derive the Archive.org identifier from version download URLs
- render a torrent download button beneath the version history in the app modal when an identifier is available
- style the torrent button so it aligns with the existing download controls

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68c87967a31883298cc2ff0833911986

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Download Torrent button in the app details modal’s Version History when a matching archive is detected, linking directly to the torrent file. Existing version display and tags remain unchanged.

* **Style**
  * Introduced styling for the torrent button and its container (right-aligned layout, spacing, and amber-colored icon).
  * Minor CSS formatting cleanup with no visual impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->