### PR TITLE
Update search query parsing for quoted filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,8 +44,8 @@
             <button class="cancel-btn" id="cancelSearch">Cancel</button>
         </div>
         <div class="search-instructions" style="margin-top: 10px; color: #aaa; font-size: 13px; text-align: left;">
-            type <b>developer:{developer-name}</b> to find apps from a specific developer (example, <b><a href="https://theoriginalhotshot.github.io/iOS-App-Archive/?query=developer%3Adisney" style="color: inherit; text-decoration: underline;">developer:Disney</a></b> or <b><a href="https://theoriginalhotshot.github.io/iOS-App-Archive/?query=jelly+developer%3Adisney" style="color: inherit; text-decoration: underline;">Jelly developer:Disney</a></b>)<br><br>
-            type <b>category:{category-name}</b> to find apps from a specific category (example, <b><a href="https://theoriginalhotshot.github.io/iOS-App-Archive/?query=category%3Agames" style="color: inherit; text-decoration: underline;">category:Games</a></b> or <b><a href="https://theoriginalhotshot.github.io/iOS-App-Archive/?query=ibeer+category%3Abeer" style="color: inherit; text-decoration: underline;">iBeer category:Beer</a></b>)
+            type <b>developer:"{developer-name}"</b> to find apps from a specific developer (example, <b><a href="https://theoriginalhotshot.github.io/iOS-App-Archive/?query=developer%3A%22disney%22" style="color: inherit; text-decoration: underline;">developer:"Disney"</a></b> or <b><a href="https://theoriginalhotshot.github.io/iOS-App-Archive/?query=jelly+developer%3A%22disney%22" style="color: inherit; text-decoration: underline;">Jelly developer:"Disney"</a></b>)<br><br>
+            type <b>category:"{category-name}"</b> to find apps from a specific category (example, <b><a href="https://theoriginalhotshot.github.io/iOS-App-Archive/?query=category%3A%22games%22" style="color: inherit; text-decoration: underline;">category:"Games"</a></b> or <b><a href="https://theoriginalhotshot.github.io/iOS-App-Archive/?query=ibeer+category%3A%22beer%22" style="color: inherit; text-decoration: underline;">iBeer category:"Beer"</a></b>)
         </div>
     </div>
     


### PR DESCRIPTION
## Summary
- update the search instructions to document the quoted developer and category filters
- add shared logic to parse developer and category filters wrapped in quotes when searching
- reuse the shared parser when restoring search results from URL parameters

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd2172fee48329b96dab28ebcb36cb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated search instructions to require quoted values for developer and category filters (e.g., `developer:"name"`, `category:"type"`).
  * Example URLs updated to reflect the new search syntax.

* **Improvements**
  * Standardized search filtering behavior for consistent query results throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->