### PR TITLE
Preserve category selection when returning to the categories tab

### DIFF
--- a/script.js
+++ b/script.js
@@ -3235,6 +3235,12 @@
                     searchContainer.style.display = 'block';
                     searchResults.classList.add('active');
                     tabContents.search.classList.add('active');
+                    const queryParam = getUrlParam('query');
+                    if (queryParam !== null) {
+                        searchInput.value = queryParam;
+                    }
+                    const searchTerm = queryParam !== null ? queryParam : searchInput.value;
+                    const filteredApps = filterAppsByQuery(searchTerm);
                     const pageParam = parseInt(getUrlParam('page'));
                     const page = (!isNaN(pageParam) && pageParam >= 1) ? pageParam : 1;
                     if (page === 1) {
@@ -3242,13 +3248,18 @@
                     } else {
                         setUrlParam('page', page);
                     }
-                    renderSearchResults(apps, page);
+                    renderSearchResults(filteredApps, page);
                 } else if (tabName === 'categories') {
                     carouselContainer.style.display = 'none';
                     searchContainer.style.display = 'none';
                     searchResults.classList.remove('active');
                     tabContents.categories.classList.add('active');
-                    renderCategoryList();
+                    const categoryParam = getUrlParam('category');
+                    if (categoryParam) {
+                        renderAppsForCategory(categoryParam);
+                    } else {
+                        renderCategoryList();
+                    }
                 } else {
                     // For categories, genius, updates
                     carouselContainer.style.display = 'none';


### PR DESCRIPTION
## Summary
- detect the current category URL parameter when activating the categories tab
- re-render the previously selected category's app list when the parameter is present

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6902350346648329990b69394a77db53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search queries and category filters are now reflected in the URL, making results shareable and bookmarkable.
  * Featured content dynamically filters based on URL query parameters.
  * Category views render content based on URL category parameters for consistent navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->