### PR TITLE
Restore cancel button visibility in search bar

### DIFF
--- a/script.js
+++ b/script.js
@@ -504,6 +504,7 @@
                         setUrlParam('page', page);
                     }
                     renderSearchResults(filteredApps, page);
+                    updateCancelVisibility();
                 } else if (tabName === 'categories') {
                     carouselContainer.style.display = 'none';
                     searchContainer.style.display = 'none';
@@ -569,7 +570,16 @@
             });
         }
 
-         // Search functionality
+        function updateCancelVisibility() {
+            const hasText = searchInput.value.trim().length > 0;
+            if (document.activeElement === searchInput || hasText) {
+                cancelSearch.classList.add('visible');
+            } else {
+                cancelSearch.classList.remove('visible');
+            }
+        }
+
+        // Search functionality
         searchInput.addEventListener('input', function() {
             if (!appsLoaded) {
                 return;
@@ -579,20 +589,15 @@
             setUrlParam('page', '');
             const filteredApps = filterAppsByQuery(searchTerm);
             renderSearchResults(filteredApps, 1);
+            updateCancelVisibility();
         });
-        
+
         // Show cancel button when search input is focused
-        searchInput.addEventListener('focus', function() {
-            cancelSearch.style.display = 'block';
-        });
-        
+        searchInput.addEventListener('focus', updateCancelVisibility);
+
         // Hide cancel button when search input is blurred
-        searchInput.addEventListener('blur', function() {
-            if (this.value === '') {
-                cancelSearch.style.display = 'none';
-            }
-        });
-        
+        searchInput.addEventListener('blur', updateCancelVisibility);
+
         // Cancel search
         cancelSearch.addEventListener('click', function() {
             if (!appsLoaded) {
@@ -600,7 +605,7 @@
             }
             searchInput.value = '';
             searchInput.blur();
-            this.style.display = 'none';
+            cancelSearch.classList.remove('visible');
             setUrlParam('query', '');
             renderSearchResults(apps);
         });


### PR DESCRIPTION
## Summary
- add a helper to toggle the search cancel button based on focus and input text
- update search interactions to keep the cancel button visible while typing or when a query is loaded
- hide the cancel button cleanly after clearing a search

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940741d7b18832980356a131b53c020)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the cancel button's visibility behavior in the search input. The button now displays and hides more reliably based on focus state and text content, ensuring consistent responsiveness during search operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->