### PR TITLE
Update tab URLs to reflect selected view

### DIFF
--- a/script.js
+++ b/script.js
@@ -27,6 +27,9 @@
         const cancelSearch = document.getElementById('cancelSearch');
         const tabs = document.querySelectorAll('.tab');
         const modalContainer = document.getElementById('modalContainer');
+
+        const TAB_NAMES = ['featured', 'categories', 'genius', 'search', 'updates'];
+        const TAB_NAME_SET = new Set(TAB_NAMES);
         
         // Tab content areas
         const tabContents = {
@@ -464,10 +467,47 @@
             setUrlParam('app', appId);
         }
         
+        function getBasePath(pathname = window.location.pathname) {
+            const hadTrailingSlash = pathname.endsWith('/');
+            const segments = pathname.split('/').filter(Boolean);
+            const lastSegment = segments[segments.length - 1];
+            const lastIsTab = lastSegment && TAB_NAME_SET.has(lastSegment.toLowerCase());
+            if (lastIsTab) {
+                segments.pop();
+            }
+            if (segments.length === 0) return '/';
+            const base = '/' + segments.join('/');
+            const shouldHaveTrailingSlash = hadTrailingSlash || lastIsTab;
+            return shouldHaveTrailingSlash ? `${base}/` : base;
+        }
+
+        function updateTabInUrl(tabName) {
+            const normalizedTab = (tabName || '').toLowerCase();
+            const basePath = getBasePath();
+            const trimmedBase = basePath.endsWith('/') && basePath !== '/' ? basePath.slice(0, -1) : basePath;
+            const targetPath = normalizedTab === 'featured' ? basePath : `${trimmedBase === '/' ? '' : trimmedBase}/${normalizedTab}`;
+            const newUrl = targetPath + (window.location.search ? window.location.search : '');
+            const currentUrl = window.location.pathname + window.location.search;
+            if (newUrl !== currentUrl) {
+                window.history.replaceState({}, '', newUrl);
+            }
+        }
+
+        function getTabFromPath(pathname = window.location.pathname) {
+            const segments = pathname.split('/').filter(Boolean);
+            if (segments.length === 0) return 'featured';
+            const lastSegment = segments[segments.length - 1].toLowerCase();
+            if (TAB_NAME_SET.has(lastSegment)) {
+                return lastSegment;
+            }
+            return 'featured';
+        }
+
         // Tab switching
         tabs.forEach(tab => {
             tab.addEventListener('click', function() {
                 const tabName = this.getAttribute('data-tab');
+                updateTabInUrl(tabName);
                 // Update active tab
                 tabs.forEach(t => t.classList.remove('active'));
                 this.classList.add('active');
@@ -624,6 +664,14 @@
             }
 
             initCarousel();
+
+            const pathTab = getTabFromPath();
+            if (pathTab && pathTab !== 'featured') {
+                const matchingTab = document.querySelector(`.tab[data-tab="${pathTab}"]`);
+                if (matchingTab) {
+                    matchingTab.click();
+                }
+            }
 
             // Add keyboard navigation
             document.addEventListener('keydown', function(e) {


### PR DESCRIPTION
## Summary
- update tab click handling to rewrite the URL path with the selected tab while preserving any existing query parameters
- detect tab selection from the current path so direct tab URLs automatically activate the correct view

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69419c349b9c8329b2b35e6eea567263)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tabs now sync with the URL for easy sharing—users can bookmark or share links to specific tabs
  * App automatically loads the correct tab when opening a saved URL

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->